### PR TITLE
🐛 deps: detect and repair a native module that was never built

### DIFF
--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -1,27 +1,51 @@
 import { existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 
 const pluginRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const nodeModules = join(pluginRoot, "node_modules");
+const require = createRequire(pathToFileURL(join(pluginRoot, "noop.js")));
 
-// Checking only that node_modules exists treats a half-finished install as
-// success: an interrupted first run leaves the directory behind, and Beacon
-// then fails on a missing module every session with no way to recover.
-// Verify the packages actually required are present.
-const REQUIRED = ["better-sqlite3", "sqlite-vec", "picomatch"];
-const depsUsable = existsSync(nodeModules) && REQUIRED.every((d) => existsSync(join(nodeModules, d)));
+// Checking that node_modules exists treats a half-finished install as success:
+// an interrupted first run leaves the directory behind and Beacon then fails on
+// a missing module every session with no path to recovery.
+//
+// Checking that each package *directory* exists is not enough either.
+// `npm install --omit=dev` can leave better-sqlite3 fully unpacked with no
+// compiled binary inside it — the prebuild download fails, the source build is
+// skipped, and every path check passes.
+//
+// Requiring the module is also not enough: better-sqlite3 resolves its native
+// binding lazily on first construction, so `require` returns a working function
+// with zero .node files on disk. The only honest test is to open a database.
+const PURE_JS = ["picomatch", "sqlite-vec"];
 
-if (!depsUsable) {
+function depsUsable() {
+  if (!existsSync(nodeModules)) return false;
+  if (!PURE_JS.every((d) => existsSync(join(nodeModules, d)))) return false;
+  try {
+    const Database = require("better-sqlite3");
+    new Database(":memory:").close();   // forces the native binding to load
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function run(cmd, args) {
+  execFileSync(cmd, args, {
+    cwd: pluginRoot,
+    timeout: 120_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+if (!depsUsable()) {
   process.stderr.write("Beacon: installing dependencies (first run)...\n");
   try {
-    execFileSync("npm", ["install", "--production", "--no-audit", "--no-fund"], {
-      cwd: pluginRoot,
-      timeout: 120_000,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    process.stderr.write("Beacon: dependencies installed successfully.\n");
+    run("npm", ["install", "--omit=dev", "--no-audit", "--no-fund"]);
   } catch (err) {
     process.stderr.write(
       `Beacon: failed to install dependencies. Run 'npm install' manually in ${pluginRoot}\n`
@@ -29,4 +53,28 @@ if (!depsUsable) {
     if (err.stderr) process.stderr.write(err.stderr.toString());
     process.exit(1);
   }
+
+  // Install can succeed while the native addon is still missing, so verify by
+  // loading it and rebuild from source if it will not load. Without this the
+  // plugin installs "successfully" and then fails on every command.
+  if (!depsUsable()) {
+    process.stderr.write("Beacon: native module missing after install — rebuilding...\n");
+    try {
+      run("npm", ["rebuild", "better-sqlite3"]);
+    } catch (err) {
+      process.stderr.write(
+        `Beacon: could not build better-sqlite3. Run 'npm rebuild better-sqlite3' in ${pluginRoot}\n`
+      );
+      if (err.stderr) process.stderr.write(err.stderr.toString());
+      process.exit(1);
+    }
+  }
+
+  if (!depsUsable()) {
+    process.stderr.write(
+      `Beacon: dependencies still unusable after install and rebuild. See ${pluginRoot}\n`
+    );
+    process.exit(1);
+  }
+  process.stderr.write("Beacon: dependencies installed successfully.\n");
 }

--- a/scripts/lib/open-db.js
+++ b/scripts/lib/open-db.js
@@ -10,6 +10,23 @@ import { unlinkSync } from 'fs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = path.resolve(__dirname, '..', '..');
 
+// A native module can be unusable in more ways than an ABI mismatch, and only
+// one of them says NODE_MODULE_VERSION. `npm install --production` can leave
+// better-sqlite3's directory in place with no compiled binary at all — the
+// prebuild download fails, the source build is skipped, and the package looks
+// installed. That surfaces as "Could not locate the bindings file", which the
+// old check did not match, so the rebuild that would have fixed it never ran
+// and every Beacon command died on a fresh install.
+export function needsNativeRebuild(err) {
+  const m = String(err && err.message);
+  return m.includes('NODE_MODULE_VERSION')          // built for another Node ABI
+    || m.includes('Could not locate the bindings')   // never built at all
+    || m.includes('invalid ELF header')              // built for another platform
+    || m.includes('was compiled against a different') // node-gyp phrasing
+    || m.includes('mach-o, but wrong architecture')  // arm64 vs x64 on macOS
+    || m.includes('symbol not found');               // partially linked binary
+}
+
 export function openDatabase(dbPath, dimensions) {
   try {
     return new BeaconDatabase(dbPath, dimensions);
@@ -23,7 +40,7 @@ export function openDatabase(dbPath, dimensions) {
       return new BeaconDatabase(dbPath, dimensions);
     }
 
-    if (!err.message.includes('NODE_MODULE_VERSION')) throw err;
+    if (!needsNativeRebuild(err)) throw err;
 
     // Guard against infinite re-exec loop
     if (process.env.__BEACON_REEXEC) {

--- a/tests/db-new-methods.test.js
+++ b/tests/db-new-methods.test.js
@@ -153,3 +153,35 @@ describe('BeaconDatabase new methods', () => {
     });
   });
 });
+
+describe('needsNativeRebuild', () => {
+  it('catches an ABI mismatch', async () => {
+    const { needsNativeRebuild } = await import('../scripts/lib/open-db.js');
+    expect(needsNativeRebuild(new Error(
+      'The module was compiled against a different Node.js version using NODE_MODULE_VERSION 115.'
+    ))).toBe(true);
+  });
+
+  it('catches a binding that was never built', async () => {
+    // `npm install --production` can leave the package directory in place with
+    // no compiled binary. This message is what that looks like, and matching
+    // only NODE_MODULE_VERSION missed it entirely.
+    const { needsNativeRebuild } = await import('../scripts/lib/open-db.js');
+    expect(needsNativeRebuild(new Error(
+      'Could not locate the bindings file. Tried:\n → .../better_sqlite3.node'
+    ))).toBe(true);
+  });
+
+  it('catches a binary built for the wrong architecture', async () => {
+    const { needsNativeRebuild } = await import('../scripts/lib/open-db.js');
+    expect(needsNativeRebuild(new Error('mach-o, but wrong architecture'))).toBe(true);
+    expect(needsNativeRebuild(new Error('invalid ELF header'))).toBe(true);
+  });
+
+  it('does not rebuild for unrelated failures', async () => {
+    const { needsNativeRebuild } = await import('../scripts/lib/open-db.js');
+    expect(needsNativeRebuild(new Error('database disk image is malformed'))).toBe(false);
+    expect(needsNativeRebuild(new Error('SQLITE_BUSY: database is locked'))).toBe(false);
+    expect(needsNativeRebuild(new Error('no such table: chunks'))).toBe(false);
+  });
+});


### PR DESCRIPTION
A fresh marketplace install left better-sqlite3 unpacked with no compiled binary: the prebuild download fails, the source build is skipped, and npm reports success. Every Beacon command then died on "Could not locate the bindings file" with no way to recover.

Two guards both missed it. ensure-deps checked that the package directory existed, which it did. And openDatabase only rebuilt when the error mentioned NODE_MODULE_VERSION, so a binding that was never built at all fell straight through to a throw.

Requiring the module is not a sufficient check either — better-sqlite3 resolves its binding lazily on first construction, so `require` returns a working function with zero .node files on disk. ensure-deps now opens an in-memory database to force the load, and falls back to `npm rebuild` when install alone does not produce a usable module. Verified against the real broken state: install alone did not fix it, the rebuild did.

openDatabase now also recognises a missing binding, a wrong-architecture binary and a partially linked one, not just an ABI mismatch.