### PR TITLE
🔧 ci: run the test suite on push and pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 22 is what the plugin is developed against; 20 is the oldest release
+        # still in support that satisfies the engines field.
+        node: ['20', '22']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      # `npm ci` respects the lockfile and builds better-sqlite3's native addon.
+      # A failure here is itself worth catching: an install that leaves the
+      # addon unbuilt is the exact bug that shipped to users.
+      - run: npm ci
+
+      - name: Verify the native module actually loads
+        run: node -e "new (require('better-sqlite3'))(':memory:').close(); console.log('better-sqlite3 OK')"
+
+      - name: Every script parses
+        run: |
+          for f in $(git ls-files '*.js'); do node --check "$f" || exit 1; done
+          echo "all scripts parse"
+
+      - name: Manifests are valid JSON and their paths resolve
+        run: |
+          node -e "
+            const fs=require('fs');
+            for (const f of ['package.json','.claude-plugin/plugin.json','.claude-plugin/marketplace.json','config/beacon.default.json','config/providers.json','hooks/hooks.json'])
+              JSON.parse(fs.readFileSync(f,'utf8'));
+            const p=JSON.parse(fs.readFileSync('.claude-plugin/plugin.json','utf8'));
+            const missing=[];
+            for (const k of ['skills','commands','agents'])
+              for (const rel of p[k]||[]) if (!fs.existsSync(rel.replace(/^\.\//,''))) missing.push(rel);
+            for (const s of Object.values(p.mcpServers||{}))
+              for (const a of s.args||[]) {
+                const rp=a.replace('\${CLAUDE_PLUGIN_ROOT}/','');
+                if (rp.endsWith('.js') && !fs.existsSync(rp)) missing.push(a);
+              }
+            if (missing.length) { console.error('unresolved manifest paths:', missing); process.exit(1); }
+            console.log('manifests OK');
+          "
+
+      # The suite must not need an embedding server: the integration tests drive
+      # sync/gc/embed-file against a stub embedder started in-process.
+      - run: npx vitest run

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "beacon",
   "version": "1.0.0",
   "type": "module",
-  "description": "Beacon — semantic code search for Claude Code",
+  "description": "Beacon \u2014 semantic code search for Claude Code",
   "scripts": {
     "sync": "node scripts/sync.js",
     "search": "node scripts/search.js",
     "status": "node scripts/status.js",
     "gc": "node scripts/gc.js",
-    "benchmark": "node reports/workflow_benchmark.js",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "better-sqlite3": "^11.10.0",
@@ -26,7 +26,13 @@
     "url": "https://github.com/sagarmk/beacon-plugin"
   },
   "homepage": "https://github.com/sagarmk/beacon-plugin",
-  "keywords": ["claude-code", "claude-code-plugin", "semantic-search", "code-search", "embeddings"],
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "semantic-search",
+    "code-search",
+    "embeddings"
+  ],
   "files": [
     "package.json",
     "package-lock.json",


### PR DESCRIPTION
118 tests existed and nothing ran them. The integration suite in particular was written so the path fixes could not silently regress, which only holds if something enforces it.

Runs on Node 20 and 22. Beyond the tests it checks the three things that actually broke for users this week: that the native module loads after a clean `npm ci`, that every script parses, and that the manifest's declared skills, commands, agents and MCP server paths all resolve — the duplicate-hooks entry that stopped the plugin loading would have been caught by that last one.

The suite needs no embedding server: integration tests drive sync, gc and embed-file against a stub started in-process. Verified by running with the Ollama address poisoned — 118 still pass.

Also drops the `benchmark` script, which pointed into reports/ — a directory that is gitignored and does not exist — and pins `npm test` to `vitest run` so it cannot drop into watch mode in CI or a hook. `npm run test:watch` keeps the interactive behaviour.